### PR TITLE
Don't set null on M2M fields

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -91,7 +91,7 @@ If you want to change the type of an object without refreshing it from the datab
 Limitations
 ===========
 
-Since all objects are stored in the same table, all fields defined in subclasses are nullable.
+Since all objects are stored in the same table, all fields defined in subclasses are nullable with the exception of ManyToManyFields. Django's system check warns that setting ``null=True`` on ManyToManyFields has no effect so the ``null`` attribute ManyToManyFields is left as is while all other field types have ``null`` set to ``False``.
 
 Known issues
 ============

--- a/README.rst
+++ b/README.rst
@@ -91,7 +91,7 @@ If you want to change the type of an object without refreshing it from the datab
 Limitations
 ===========
 
-Since all objects are stored in the same table, all fields defined in subclasses are nullable with the exception of ManyToManyFields. Django's system check warns that setting ``null=True`` on ManyToManyFields has no effect so the ``null`` attribute ManyToManyFields is left as is while all other field types have ``null`` set to ``False``.
+Since all objects are stored in the same table, all fields defined in subclasses are nullable.
 
 Known issues
 ============

--- a/typedmodels/models.py
+++ b/typedmodels/models.py
@@ -84,7 +84,7 @@ class TypedModelMetaclass(ModelBase):
                 # In Django 1.8+, warnings will be triggered by the system
                 # check for M2M fields setting if we set null to True. Prevent
                 # those warnings by setting null only for non-M2M fields.
-                if not field.many_to_many:
+                if django.VERSION < (1, 8) or not field.many_to_many:
                     field.null = True
                 if isinstance(field, models.fields.related.RelatedField):
                     # Monkey patching field instance to make do_related_class use created class instead of base_class.

--- a/typedmodels/models.py
+++ b/typedmodels/models.py
@@ -81,7 +81,11 @@ class TypedModelMetaclass(ModelBase):
             declared_fields = dict((name, element) for name, element in classdict.items() if isinstance(element, Field))
 
             for field_name, field in declared_fields.items():
-                field.null = True
+                # In Django 1.8+, warnings will be triggered by the system
+                # check for M2M fields setting if we set null to True. Prevent
+                # those warnings by setting null only for non-M2M fields.
+                if not field.many_to_many:
+                    field.null = True
                 if isinstance(field, models.fields.related.RelatedField):
                     # Monkey patching field instance to make do_related_class use created class instead of base_class.
                     # Actually that class doesn't exist yet, so we just monkey patch base_class for a while,


### PR DESCRIPTION
This PR changes the behavior of `django-typed-models` so that the `null` attribute is not set on M2M fields. Currently, `django-typed-models` [wants to set `null=True` for all fields](https://github.com/craigds/django-typed-models/blob/ca38c11f751ec4d057c3bb3ca6645c4c43ddccc4/typedmodels/models.py#L84). Looking at the [README](https://github.com/craigds/django-typed-models/tree/master#limitations), we see this is marked as a limitation:

```
Since all objects are stored in the same table, all fields defined in subclasses are nullable.
```

Django, however, recognizes that setting `null=True` has no effect on M2M fields. When an M2M field has `null=True`, the Django system check will generate warnings of the form:

```
<app>.<model>.<field>: (fields.W340) null has no effect on ManyToManyField.
```

To avoid these warnings in applications that use `django-typed-model`, this PR updates the original behavior to ignore M2M fields. For all non-M2M fields, `null` is still set to true. If, however, a field is M2M, the `null` attribute is left alone.