### PR TITLE
fix the Choices for TypedModel.type when using Django 1.9

### DIFF
--- a/typedmodels/models.py
+++ b/typedmodels/models.py
@@ -130,9 +130,12 @@ class TypedModelMetaclass(ModelBase):
             if typ in base_class._typedmodels_registry:
                 raise ValueError("Can't register %s type %r to %r (already registered to %r )" % (typ, classname, base_class._typedmodels_registry))
             base_class._typedmodels_registry[typ] = cls
+
             type_name = getattr(cls._meta, 'verbose_name', cls.__name__)
             type_field = base_class._meta.get_field('type')
-            type_field._choices = tuple(list(type_field.choices) + [(typ, type_name)])
+            choices = tuple(list(type_field.choices) + [(typ, type_name)])
+            choices_field = '_choices' if django.VERSION < (1, 9) else 'choices'
+            setattr(type_field, choices_field, choices)
 
             cls._meta.declared_fields = declared_fields
 

--- a/typedmodels/tests.py
+++ b/typedmodels/tests.py
@@ -46,6 +46,10 @@ class TestTypedModels(SetupStuff):
         self.assertEqual(set(Canine.get_type_classes()), set([Canine]))
         self.assertEqual(set(Feline.get_type_classes()), set([BigCat, AngryBigCat, Feline]))
 
+    def test_type_choices(self):
+        type_choices = set((cls for cls, _  in Animal._meta.get_field('type').choices))
+        self.assertEqual(type_choices, set(Animal.get_types()))
+
     def test_base_model_queryset(self):
         # all objects returned
         qs = Animal.objects.all().order_by('type')


### PR DESCRIPTION
In Django 1.9 django.db.models.fields.Field no longer has '_choices' as a field and 'choices' as a property, directly using the field 'choices'.
This patch will ensure that the proper Choices are populated for TypedModel.type.