### PR TITLE
Test against Django 1.11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ env:
   - PIP_DJANGO='Django>=1.8,<1.9'
   - PIP_DJANGO='Django>=1.9,<1.10'
   - PIP_DJANGO='Django>=1.10,<1.11'
+  - PIP_DJANGO='Django>=1.11,<1.12'
 install:
   - "pip install $PIP_DJANGO"
   - "pip install pyyaml coveralls"

--- a/runtests.py
+++ b/runtests.py
@@ -11,9 +11,5 @@ settings.configure(
 
 django.setup()
 
-from django.test.utils import setup_test_environment
-setup_test_environment()
-
-
 from django.core.management import call_command
 call_command('test', 'typedmodels', verbosity=2)

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 
 [tox]
 envlist = {py27,py33,py34,py35,pypy}-{dj18}
-          {py27,py34,py35,pypy}-{dj19,dj110}
+          {py27,py34,py35,pypy}-{dj19,dj110,dj111}
 
 toxworkdir = {homedir}/.tox-django-typed-models
 
@@ -23,3 +23,4 @@ deps =
     dj18: Django>=1.8,<1.9
     dj19: Django>=1.9,<1.10
     dj110: Django>=1.10,<1.11
+    dj111: Django>=1.11,<1.12


### PR DESCRIPTION
Django 1.11 is now a [LTS release](https://www.djangoproject.com/weblog/2017/apr/04/django-111-released/). 