### PR TITLE
Handle virtual fields correctly; e.g. GenericRelations

### DIFF
--- a/runtests.py
+++ b/runtests.py
@@ -3,7 +3,7 @@ import django
 from django.conf import settings
 
 settings.configure(
-    INSTALLED_APPS=('typedmodels',),
+    INSTALLED_APPS=('typedmodels', 'django.contrib.contenttypes', ),
     MIDDLEWARE_CLASSES=(),
     DATABASES={
         'default': {'ENGINE': 'django.db.backends.sqlite3'}

--- a/typedmodels/models.py
+++ b/typedmodels/models.py
@@ -206,6 +206,8 @@ class TypedModelMetaclass(ModelBase):
             return True
         if m2m in (False, None) and f in base_class._meta._typedmodels_original_fields:
             return True
+        if f in base_class._meta.virtual_fields:
+            return True
         for ancestor in cls.mro():
             if issubclass(ancestor, base_class) and ancestor != base_class:
                 if f in ancestor._meta.declared_fields.values():
@@ -229,7 +231,6 @@ class TypedModelMetaclass(ModelBase):
             cache_key = (forward, reverse, include_parents, include_hidden, seen_models is None)
 
             was_cached = cache_key in self._get_fields_cache
-
             fields = orig_get_fields(
                 forward=forward,
                 reverse=reverse,
@@ -237,7 +238,6 @@ class TypedModelMetaclass(ModelBase):
                 include_hidden=include_hidden,
                 seen_models=seen_models
             )
-
             # If it was cached already, it's because we've already filtered this, skip it
             if not was_cached:
                 fields = [f for f in fields if TypedModelMetaclass._model_has_field(cls, base_class, f)]

--- a/typedmodels/test_models.py
+++ b/typedmodels/test_models.py
@@ -1,13 +1,30 @@
-
+from django.contrib.contenttypes.fields import GenericForeignKey, GenericRelation
+from django.contrib.contenttypes.models import ContentType
 from django.db import models
+from django.db.models import ForeignKey, PositiveIntegerField, CharField
 from django.utils.encoding import python_2_unicode_compatible
 from typedmodels.models import TypedModel
 
 from django.utils.six import text_type
 
 
+class UniqueIdentifier(models.Model):
+    referent = GenericForeignKey()
+    content_type = ForeignKey(ContentType, null=True, blank=True)
+    object_id = PositiveIntegerField(null=True, blank=True)
+    created = models.DateTimeField(db_index=True, auto_now_add=True)
+    name = CharField(max_length=255)
+
+
+class UniqueIdentifierMixin(models.Model):
+    unique_identifiers = GenericRelation(UniqueIdentifier, related_query_name='referents')
+
+    class Meta:
+        abstract = True
+
+
 @python_2_unicode_compatible
-class Animal(TypedModel):
+class Animal(TypedModel, UniqueIdentifierMixin):
     """
     Abstract model
     """
@@ -50,7 +67,7 @@ class AngryBigCat(BigCat):
     """
     canines_eaten = models.ManyToManyField(
         Canine
-        )
+    )
 
     def say_something(self):
         return "raawr"


### PR DESCRIPTION
Fixes a bug that causes virtual fields, e.g. GenericRelations, to not be inherited.