### PR TITLE
Expose _filter_by_type as a method

### DIFF
--- a/typedmodels/models.py
+++ b/typedmodels/models.py
@@ -22,6 +22,9 @@ from collections import OrderedDict
 class TypedModelManager(models.Manager):
     def get_queryset(self):
         qs = super(TypedModelManager, self).get_queryset()
+        return self._filter_by_type(qs)
+
+    def _filter_by_type(self, qs):
         if hasattr(self.model, '_typedmodels_type'):
             if len(self.model._typedmodels_subtypes) > 1:
                 qs = qs.filter(type__in=self.model._typedmodels_subtypes)


### PR DESCRIPTION
A small change to allow subclasses of `TypedModelManager` to more easily change their queryset type.

Example use case:

```python
class PersonQuerySet(models.QuerySet):
    pass

class PersonManager(TypedModelManager):

    def get_queryset(self):
        qs = PersonQuerySet(self.model, using=self._db)
        return self._filter_by_type(qs)
```