### PR TITLE
Remove manager magic for next release

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,12 @@
 
 Backward-incompatible changes for released versions are listed here (for 0.5 onwards.)
 
+## 0.7
+This release removes some magic around manager setup. Managers are now inherited using the normal Django mechanism.
+
+If you are using a custom default manager on a TypedModel subclass, you need to make sure it is a subclass
+of TypedModelManager. Otherwise type filtering will not work as expected.
+
 ## 0.5
 
 This import path no longer works, as recent Django changes make it impossible:

--- a/typedmodels/models.py
+++ b/typedmodels/models.py
@@ -162,21 +162,6 @@ class TypedModelMetaclass(ModelBase):
             cls._meta._typedmodels_original_fields = cls._meta.fields
             cls._meta._typedmodels_original_many_to_many = cls._meta.many_to_many
 
-            # set default manager. this will be inherited by subclasses, since they are proxy models
-            manager = None
-            if not cls._default_manager:
-                manager = TypedModelManager()
-            elif not isinstance(cls._default_manager, TypedModelManager):
-                class Manager(TypedModelManager, cls._default_manager.__class__):
-                    pass
-                cls._default_manager.__class__ = Manager
-                manager = cls._default_manager
-            if manager is not None:
-                cls.add_to_class('objects', manager)
-                if django.VERSION < (1, 10):
-                    # _default_manager became readonly in django 1.10. luckily we don't actually need it.
-                    cls._default_manager = cls.objects
-
             # add a get_type_classes classmethod to allow fetching of all the subclasses (useful for admin)
 
             def get_type_classes(subcls):

--- a/typedmodels/test_models.py
+++ b/typedmodels/test_models.py
@@ -88,6 +88,8 @@ class AbstractVegetable(TypedModel):
     color = models.CharField(max_length=255)
     yumness = models.FloatField(null=False)
 
+    mymanager = models.Manager()
+
 
 class Fruit(AbstractVegetable):
     pass

--- a/typedmodels/tests.py
+++ b/typedmodels/tests.py
@@ -1,6 +1,7 @@
 import unittest
 
 from django.contrib.contenttypes.models import ContentType
+from django.db import models
 
 try:
     import yaml
@@ -12,6 +13,7 @@ except ImportError:
 from django.core import serializers
 from django.test import TestCase
 
+from .models import TypedModelManager
 from .test_models import AngryBigCat, Animal, BigCat, Canine, Feline, Parrot, AbstractVegetable, Vegetable, \
     Fruit, UniqueIdentifier
 
@@ -216,3 +218,18 @@ class TestTypedModels(SetupStuff):
             cls = uid.referent.__class__
             animal = cls.objects.filter(unique_identifiers__name=uid.name)
             self.assertTrue(isinstance(animal.first(), Animal))
+
+
+class TestManagers(TestCase):
+    def test_manager_classes(self):
+        self.assertIsInstance(Animal.objects, TypedModelManager)
+        self.assertIsInstance(Feline.objects, TypedModelManager)
+        self.assertIsInstance(BigCat.objects, TypedModelManager)
+
+        # This one has a custom manager defined, but that shouldn't prevent objects from working
+        self.assertIsInstance(AbstractVegetable.mymanager, models.Manager)
+        self.assertIsInstance(AbstractVegetable.objects, TypedModelManager)
+
+        # subclasses work the same way
+        self.assertIsInstance(Vegetable.mymanager, models.Manager)
+        self.assertIsInstance(Vegetable.objects, TypedModelManager)


### PR DESCRIPTION
This is an alternative to #33. It removes magic at the cost of a small backwards-incompatibility.

We can no longer set `_default_manager` sensibly from Django 1.10. This changes the behaviour so that Django 1.8 behaves the same way. I'm not supporting django 1.9 any more.

* Managers are now inherited normally.
* Users using a custom manager now need to make sure it subclasses `TypedModelManager`.
* `TypedModel.objects` exists and will be inherited by all subclasses, so technically you can _define_ another default manager, and as long as you only care about TypedModel filtering on `objects` everything will work fine with no change in behaviour.

For most users there will be nothing to do. For others, the fix will be something like this:

```diff
-class MyManager(MyManagerBaseClass):
+class MyManager(MyManagerBaseClass, TypedModelManager):
```
