### PR TITLE
Replace deprecated `Model._meta.virtual_fields`

### DIFF
--- a/typedmodels/models.py
+++ b/typedmodels/models.py
@@ -186,7 +186,7 @@ class TypedModelMetaclass(ModelBase):
             return True
         if m2m in (False, None) and f in base_class._meta._typedmodels_original_fields:
             return True
-        if f in base_class._meta.virtual_fields:
+        if f in base_class._meta.private_fields:
             return True
         for ancestor in cls.mro():
             if issubclass(ancestor, base_class) and ancestor != base_class:


### PR DESCRIPTION
The private attribute `virtual_fields` of `Model._meta` is deprecated in favor of `private_fields` and will be removed in Django 2.0. Noted in the [deprecation timeline](https://docs.djangoproject.com/en/dev/internals/deprecation/#deprecation-removed-in-2-0) and [1.10 release notes](https://docs.djangoproject.com/en/dev/releases/1.10/).

Hopefully this makes upgrading a bit easier! 
