### PR TITLE
[Feature] Added the meta class key "type_name"

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -107,6 +107,23 @@ One current use for this is connecting signals, since currently they don't fire 
         post_save.connect(on_animal_saved, sender=sender)
 
 
+Database customization
+======================
+You can change the `type` identifier which is used in the database by specifying the meta key `type_name`
+
+.. code-block:: python
+
+    class Food(TypedModel):
+        """
+        Abstract model
+        """
+
+        class Meta:
+            type_name = 'food'
+
+This will change the default type identifier to "food".
+
+
 Limitations
 ===========
 


### PR DESCRIPTION
This makes it possible to be able to specify which identifiers the different types have in the database.
This might be useful when sharing the database of django with Hibernate.
The problem: Hibernates inheritance identifiert field is only 31 chars long so most model names are too long. 
With this PR you can manually specify the identifier of a model if you wish to do so.