### PR TITLE
Changed type of the 'type' field to foreign key to ContentType

### DIFF
--- a/typedmodels/admin.py
+++ b/typedmodels/admin.py
@@ -6,11 +6,11 @@ class TypedModelAdmin(admin.ModelAdmin):
         fields = super().get_fields(request, obj)
         # we remove the type field from the admin of subclasses.
         if TypedModel not in self.model.__bases__:
-            fields.remove(self.model._meta.get_field('type').name)
+            fields.remove(self.model._meta.get_field('dtm_type').name)
         return fields
 
     def save_model(self, request, obj, form, change):
         if getattr(obj, '_typedmodels_type', None) is None:
             # new instances don't have the type attribute
-            obj._typedmodels_type = form.cleaned_data['type']
+            obj._typedmodels_type = form.cleaned_data['dtm_type']
         obj.save()


### PR DESCRIPTION
@ https://github.com/craigds/django-typed-models/issues/56

> At the same time perhaps we should change it to be a content-type foreign key rather than a app.model string. So the actual db column would be dtm_type_id I guess.

I decided to have a go at it. It "works for me" i.e. in my hobby project (full disclosure: I'm not a web developer by trade), but it still does require more testing.

It should be a good starting point if nothing else.

I had to do a custom migration, which was easy enough, but I wonder if there is a way for a package to generate it automatically?
It's basically:
```python
    app_label, model = object.type.split('.')
    object.dtm_type_id = ContentType.objects.get(app_label=app_label, model=model).id
    object.save()
```