### PR TITLE
Allow abstract subclasses of TypedModel

### DIFF
--- a/testapp/models.py
+++ b/testapp/models.py
@@ -17,7 +17,7 @@ class UniqueIdentifier(models.Model):
 
 class UniqueIdentifierMixin(models.Model):
     unique_identifiers = GenericRelation(
-        UniqueIdentifier, related_query_name='referents'
+        UniqueIdentifier, related_query_name="referents"
     )
 
     class Meta:
@@ -100,12 +100,23 @@ class Vegetable(AbstractVegetable):
     pass
 
 
-class Parent(TypedModel):
+class SurpriseAbstractModel(TypedModel):
+    """
+    This class *isn't* the typed base, it's a random abstract model.
+    The presence of this model tests
+    https://github.com/craigds/django-typed-models/issues/61
+    """
+
+    class Meta:
+        abstract = True
+
+
+class Parent(SurpriseAbstractModel):
     a = models.CharField(max_length=1)
 
 
 class Child1(Parent):
-    b = models.OneToOneField('self', null=True, on_delete=models.CASCADE)
+    b = models.OneToOneField("self", null=True, on_delete=models.CASCADE)
 
 
 class Child2(Parent):

--- a/typedmodels/models.py
+++ b/typedmodels/models.py
@@ -50,7 +50,7 @@ class TypedModelMetaclass(ModelBase):
         while mro:
             base_class = mro.pop(-1)
             if issubclass(base_class, TypedModel) and base_class is not TypedModel:
-                if base_class._meta.proxy:
+                if base_class._meta.proxy or base_class._meta.abstract:
                     # continue up the mro looking for non-proxy base classes
                     mro.extend(base_class.__bases__)
                 else:
@@ -188,7 +188,7 @@ class TypedModelMetaclass(ModelBase):
                     superclass._typedmodels_subtypes.append(typ)
 
             meta._patch_fields_cache(cls, base_class)
-        else:
+        elif not cls._meta.abstract:
             # this is the base class
             cls._typedmodels_registry = {}
 


### PR DESCRIPTION
Allows this class hierarchy:

```
TypedModel
  ➮ abstract model
      ➮ typed base model
          ➮ typed proxy model
```

Fixes #61. @iacobfred can you check this fixes the issue for you? Thanks