### PR TITLE
Sort choices alphabetically

### DIFF
--- a/testapp/migrations/0001_initial.py
+++ b/testapp/migrations/0001_initial.py
@@ -34,7 +34,7 @@ class Migration(migrations.Migration):
             name='Animal',
             fields=[
                 ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
-                ('type', models.CharField(choices=[('testapp.canine', 'canine'), ('testapp.feline', 'feline'), ('testapp.bigcat', 'big cat'), ('testapp.angrybigcat', 'angry big cat'), ('testapp.parrot', 'parrot')], db_index=True, max_length=255)),
+                ('type', models.CharField(choices=[('testapp.angrybigcat', 'angry big cat'), ('testapp.bigcat', 'big cat'), ('testapp.canine', 'canine'), ('testapp.feline', 'feline'), ('testapp.parrot', 'parrot')], db_index=True, max_length=255)),
                 ('name', models.CharField(max_length=255)),
                 ('mice_eaten', models.IntegerField(default=0)),
                 ('known_words', models.IntegerField(null=True)),

--- a/typedmodels/models.py
+++ b/typedmodels/models.py
@@ -174,7 +174,7 @@ class TypedModelMetaclass(ModelBase):
             type_name = getattr(cls._meta, "verbose_name", cls.__name__)
             type_field = base_class._meta.get_field("type")
             choices = tuple(list(type_field.choices) + [(typ, type_name)])
-            type_field.choices = choices
+            type_field.choices = sorted(choices)
 
             cls._meta.declared_fields = declared_fields
 

--- a/typedmodels/tests.py
+++ b/typedmodels/tests.py
@@ -120,8 +120,15 @@ def test_get_type_classes():
 
 
 def test_type_choices():
-    type_choices = {cls for cls, _ in Animal._meta.get_field("type").choices}
-    assert type_choices == set(Animal.get_types())
+    type_choices = Animal._meta.get_field("type").choices
+    assert type_choices == (
+        ("testapp.angrybigcat", "angry big cat"),
+        ("testapp.bigcat", "big cat"),
+        ("testapp.canine", "canine"),
+        ("testapp.feline", "feline"),
+        ("testapp.parrot", "parrot"),
+    )
+    assert {cls for cls, _ in type_choices} == set(Animal.get_types())
 
 
 def test_base_model_queryset(animals):


### PR DESCRIPTION
Sort choices alphabetically so Django won't discover any changes if the content of the `choices` list does not change.

The test did not pass on the previous codebase as choices for the Animal model were discovered in a different order: `(('testapp.canine', 'canine'), ('testapp.feline', 'feline'), ('testapp.bigcat', 'big cat'), ('testapp.angrybigcat', 'angry big cat'), ('testapp.parrot', 'parrot'))`.

I modified the existing migration file instead of generating a new one since this app is used only in tests and it's a no-SQL change.

This change may affect existing projects by generating a new migration file if choices were not sorted alphabetically already.

Fixes #67