### PR TITLE
Fix running tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,5 +1,5 @@
 name: django-typed-models tests
-on: [push]
+on: [pull_request, push]
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -15,9 +15,9 @@ jobs:
           - "4.1"
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies (django ${{ matrix.django-version }})

--- a/typedmodels/tests.py
+++ b/typedmodels/tests.py
@@ -121,13 +121,13 @@ def test_get_type_classes():
 
 def test_type_choices():
     type_choices = Animal._meta.get_field("type").choices
-    assert type_choices == (
+    assert type_choices == [
         ("testapp.angrybigcat", "angry big cat"),
         ("testapp.bigcat", "big cat"),
         ("testapp.canine", "canine"),
         ("testapp.feline", "feline"),
         ("testapp.parrot", "parrot"),
-    )
+    ]
     assert {cls for cls, _ in type_choices} == set(Animal.get_types())
 
 


### PR DESCRIPTION
Scope of this PR:
1. Fix the error raised in tests in the master after merging my previous PR (https://github.com/craigds/django-typed-models/pull/68).
2. Fix running tests in GitHub Actions for pull requests opened from fork repositories. This way we can catch the error before merging to the master branch.
3. Update versions of the `checkout` and `setup-python` actions.