### PR TITLE
Fix proxy models inheriting indexes from abstract parents

### DIFF
--- a/testapp/migrations/0003_basemodelwithindex.py
+++ b/testapp/migrations/0003_basemodelwithindex.py
@@ -1,0 +1,55 @@
+# Migration for issue #58 - indexes on TypedModel base classes
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('testapp', '0002_developer_employee_manager'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='BaseModelWithIndex',
+            fields=[
+                ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('type', models.CharField(choices=[('testapp.submodela', 'Sub Model A'), ('testapp.submodelb', 'Sub Model B')], db_index=True, max_length=255)),
+                ('name', models.CharField(max_length=100)),
+                ('tag', models.CharField(max_length=100)),
+                ('field_a', models.CharField(max_length=100, null=True)),
+                ('field_b', models.IntegerField(null=True)),
+            ],
+            options={
+                'abstract': False,
+            },
+        ),
+        migrations.AddIndex(
+            model_name='basemodelwithindex',
+            index=models.Index(fields=['tag'], name='testapp_bas_tag_f26b85_idx'),
+        ),
+        migrations.CreateModel(
+            name='SubModelA',
+            fields=[
+            ],
+            options={
+                'verbose_name': 'Sub Model A',
+                'proxy': True,
+                'indexes': [],
+                'constraints': [],
+            },
+            bases=('testapp.basemodelwithindex',),
+        ),
+        migrations.CreateModel(
+            name='SubModelB',
+            fields=[
+            ],
+            options={
+                'verbose_name': 'Sub Model B',
+                'proxy': True,
+                'indexes': [],
+                'constraints': [],
+            },
+            bases=('testapp.basemodelwithindex',),
+        ),
+    ]

--- a/testapp/models.py
+++ b/testapp/models.py
@@ -148,3 +148,41 @@ def typed_queryset() -> None:
 def do_get_type_classes() -> None:
     for x in Animal.get_type_classes():
         print(x)
+
+
+# Test model for issue #58 - indexes on TypedModel base classes
+# The issue occurs when:
+# 1. An abstract model defines indexes
+# 2. A concrete TypedModel inherits from that abstract model
+# 3. Proxy subclasses of the TypedModel inherit the Meta with indexes
+
+
+class AbstractModelWithIndex(models.Model):
+    """Abstract model with indexes."""
+
+    name = models.CharField(max_length=100)
+    tag = models.CharField(max_length=100)
+
+    class Meta:
+        abstract = True
+        indexes = [models.Index(fields=["tag"])]
+
+
+class BaseModelWithIndex(AbstractModelWithIndex, TypedModel):
+    """Concrete TypedModel inheriting from abstract model."""
+
+    pass
+
+
+class SubModelA(BaseModelWithIndex):
+    field_a = models.CharField(max_length=100, null=True)
+
+    class Meta(BaseModelWithIndex.Meta):
+        verbose_name = "Sub Model A"
+
+
+class SubModelB(BaseModelWithIndex):
+    field_b = models.IntegerField(null=True)
+
+    class Meta(BaseModelWithIndex.Meta):
+        verbose_name = "Sub Model B"

--- a/typedmodels/models.py
+++ b/typedmodels/models.py
@@ -94,6 +94,14 @@ class TypedModelMetaclass(ModelBase):
                 )
             Meta.proxy = True
 
+            # Proxy models shouldn't define their own indexes - they share the base model's table and indexes.
+            # If we don't clear this, Django will complain that the index fields aren't local to the proxy model.
+            # See issue #58
+            if hasattr(Meta, "indexes"):
+                # Set to empty list to override any inherited indexes
+                # (delattr won't work for inherited attributes)
+                Meta.indexes = []
+
             declared_fields = dict(
                 (name, element)
                 for name, element in list(classdict.items())


### PR DESCRIPTION
When a TypedModel base class inherits from an abstract model with indexes, proxy subclasses would inherit those indexes. Django's system checks would fail because indexed fields aren't local to proxy models.

Clear inherited indexes in proxy model Meta to prevent this error.

Fixes #58