### PR TITLE
Fix closure-in-loop bug in TypedModelMetaclass.__new__

### DIFF
--- a/typedmodels/models.py
+++ b/typedmodels/models.py
@@ -127,10 +127,10 @@ class TypedModelMetaclass(ModelBase):
                     # We'll do more stuff when the class is created.
                     old_do_related_class = field.do_related_class
 
-                    def do_related_class(self, other, cls):
+                    def do_related_class(self, other, cls, _old=old_do_related_class):
                         base_class_name = base_class.__name__
                         cls._meta.model_name = classname.lower()
-                        old_do_related_class(other, cls)  # noqa: B023
+                        _old(other, cls)
                         cls._meta.model_name = base_class_name.lower()
 
                     field.do_related_class = types.MethodType(do_related_class, field)  # type: ignore


### PR DESCRIPTION
The monkey-patched do_related_class closure captures old_do_related_class by variable reference rather than value. When multiple RelatedFields are declared on a TypedModel subclass, all closures end up calling the last field's original do_related_class once the loop finishes. Fields whose lazy_related_operation resolves after the loop (deferred because the target model isn't registered yet) get contribute_to_related_class called on the wrong field instance, leaving them without m2m_field_name/m2m_column_name. I have multiple M2Ms on a typed model.

Fix by capturing the value via a default argument at definition time.